### PR TITLE
fix: non working carregar tabuleiro

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -7,46 +7,33 @@
 #define MAX_LINHAS 128
 #define MAX_COLUNAS 26
 
-int carregarTabuleiro(Tabuleiro *tab, Historico *hist, const char *ficheiro)
-{
+int carregarTabuleiro(Tabuleiro *tab, Historico *hist, const char *ficheiro) {
     char caminho[512];
-    snprintf(caminho, sizeof(caminho), "%s%s", BOARD_DIR, ficheiro);
-    if (strlen(BOARD_DIR) + strlen(ficheiro) >= sizeof(caminho))
-    {
+    int len = snprintf(caminho, sizeof(caminho), "%s%s", BOARD_DIR, ficheiro);
+    if (len < 0 || (size_t)len >= sizeof(caminho))
         return -2;
-    }
+
     FILE *f = fopen(caminho, "r");
-    if (!f)
-        return -1;
+    if (!f) return -1;
 
-    if (fscanf(f, "%d %d", &tab->linhas, &tab->colunas) != 2)
-    {
-        fclose(f);
-        return -1;
-    }
-
-    if (tab->linhas <= 0 || tab->linhas > MAX_LINHAS ||
-        tab->colunas <= 0 || tab->colunas > MAX_COLUNAS)
-    {
+    if (fscanf(f, "%d %d\n", &tab->linhas, &tab->colunas) != 2 ||
+        tab->linhas <= 0 || tab->linhas > MAX_LINHAS ||
+        tab->colunas <= 0 || tab->colunas > MAX_COLUNAS) {
         fclose(f);
         return -3;
     }
 
-    for (int i = 0; i < tab->linhas; i++)
-    {
-        if (!fgets(tab->grelha[i], tab->colunas + 1, f)) // Read a full line
-        {
+    for (int i = 0; i < tab->linhas; i++) {
+        if (!fgets(tab->grelha[i], tab->colunas + 2, f)) {
             fclose(f);
-            return -1; // Read error
-        }
-        size_t len = strlen(tab->grelha[i]);
-        if (len > 0 && tab->grelha[i][len - 1] == '\n')
-        {
-            tab->grelha[i][len - 1] = '\0';
+            return -1;
         }
 
-        if ((int)strlen(tab->grelha[i]) != tab->colunas)
-        {
+        size_t len = strlen(tab->grelha[i]);
+        if (len > 0 && tab->grelha[i][len - 1] == '\n')
+            tab->grelha[i][len - 1] = '\0';
+
+        if ((int)strlen(tab->grelha[i]) != tab->colunas) {
             fclose(f);
             return -4;
         }
@@ -58,29 +45,22 @@ int carregarTabuleiro(Tabuleiro *tab, Historico *hist, const char *ficheiro)
     return 0;
 }
 
-int gravarTabuleiro(const Tabuleiro *tab, const char *ficheiro)
-{
+int gravarTabuleiro(const Tabuleiro *tab, const char *ficheiro) {
     char caminho[512];
-    snprintf(caminho, sizeof(caminho), "%s%s", BOARD_DIR, ficheiro);
-
-    if (strlen(BOARD_DIR) + strlen(ficheiro) >= sizeof(caminho))
-    {
+    int len = snprintf(caminho, sizeof(caminho), "%s%s", BOARD_DIR, ficheiro);
+    if (len < 0 || (size_t)len >= sizeof(caminho))
         return -2;
-    }
-    FILE *f = fopen(caminho, "w");
-    if (!f)
-        return -1;
 
-    if (fprintf(f, "%d %d\n", tab->linhas, tab->colunas) < 0)
-    {
+    FILE *f = fopen(caminho, "w");
+    if (!f) return -1;
+
+    if (fprintf(f, "%d %d\n", tab->linhas, tab->colunas) < 0) {
         fclose(f);
         return -3;
     }
 
-    for (int i = 0; i < tab->linhas; i++)
-    {
-        if (fprintf(f, "%s\n", tab->grelha[i]) < 0)
-        {
+    for (int i = 0; i < tab->linhas; i++) {
+        if (fprintf(f, "%s\n", tab->grelha[i]) < 0) {
             fclose(f);
             return -3;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -55,6 +55,10 @@ int main()
         {
             desfazer(&hist, &tab);
         }
+        else if (cmd[0] == 'v')
+        {
+            mostrarTabuleiro(&tab);
+        }
         else if (cmd[0] == 's')
         {
             break;


### PR DESCRIPTION
## fix: non working carregar tabuleiro

Fixes an issue where `carregarTabuleiro` failed due to path size validation and signed/unsigned comparisons.
Simplified logic, ensured safe use of `snprintf`, and removed compiler warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new command to display the current board state during gameplay.

- **Bug Fixes**
  - Improved error handling and reliability when loading and saving game boards, ensuring safer file and string operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->